### PR TITLE
Optimisation for delegate message forwarding

### DIFF
--- a/Example/PSPDFTextViewExample/PSTSampleViewController.m
+++ b/Example/PSPDFTextViewExample/PSTSampleViewController.m
@@ -10,7 +10,7 @@
 #import "PSPDFTextView.h"
 #include <tgmath.h>
 
-@interface PSTSampleViewController () {
+@interface PSTSampleViewController () <UITextViewDelegate> {
     CGRect _keyboardRect;
     BOOL _keyboardVisible;
 }
@@ -39,6 +39,7 @@
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillHideNotification:) name:UIKeyboardWillHideNotification object:nil];
 
     PSPDFTextView *textView = [[PSPDFTextView alloc] initWithFrame:self.view.bounds];
+    textView.delegate = self;
     textView.autoresizingMask = UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleWidth;
     textView.font = [UIFont systemFontOfSize:20.f];
     textView.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
@@ -90,6 +91,17 @@
 
 - (void)dismissKeyboard {
     [self.view endEditing:YES];
+}
+
+
+- (BOOL)textViewShouldBeginEditing:(UITextView *)aTextView {
+    NSLog(@"Called %@", NSStringFromSelector(_cmd));
+    return YES;
+}
+
+- (BOOL)textViewShouldEndEditing:(UITextView *)aTextView {
+    NSLog(@"Called %@", NSStringFromSelector(_cmd));
+    return YES;
 }
 
 @end

--- a/PSPDFTextView/PSPDFTextView.m
+++ b/PSPDFTextView/PSPDFTextView.m
@@ -156,13 +156,9 @@
     return [super methodSignatureForSelector:s] ?: [(id)self.realDelegate methodSignatureForSelector:s];
 }
 
-- (void)forwardInvocation:(NSInvocation *)invocation {
+- (id)forwardingTargetForSelector:(SEL)s {
     id delegate = self.realDelegate;
-    if ([delegate respondsToSelector:invocation.selector]) {
-        [invocation invokeWithTarget:delegate];
-    }else {
-        [super forwardInvocation:invocation];
-    }
+    return [delegate respondsToSelector:s] ? delegate : [super forwardingTargetForSelector:s];
 }
 
 @end


### PR DESCRIPTION
Looks like forwardInvocation: is an overhead for calling delegate methods in this case. Only target should be changed, arguments and selector are unmodified.
