### PR TITLE
Fixed bug that caused some UIScrollView delegate method to not fire

### DIFF
--- a/PSPDFTextView/PSPDFTextView.m
+++ b/PSPDFTextView/PSPDFTextView.m
@@ -38,8 +38,12 @@
 
 - (void)setDelegate:(id<UITextViewDelegate>)delegate {
     if (PSPDFRequiresTextViewWorkarounds()) {
-        [super setDelegate:delegate ? self : nil];
+        // UIScrollView delegate keeps some flags that mark whether the delegate implements some methods (like scrollViewDidScroll:)
+        // setting *the same* delegate doesn't recheck the flags, so it's better to simply nil the previous delegate out
+        // we have to setup the realDelegate at first, since the flag check happens in setter
+        [super setDelegate:nil];
         self.realDelegate = delegate != self ? delegate : nil;
+        [super setDelegate:delegate ? self : nil];
     }else {
         [super setDelegate:delegate];
     }


### PR DESCRIPTION
Presumably for performance reasons `UIScrollView` has some flags that mark whether its delegate implements some of the UIScrollViewDelegate methods:

```
...
unsigned int delegateScrollViewDidScroll : 1; 
unsigned int delegateScrollViewDidZoom : 1; 
unsigned int delegateContentSizeForZoomScale : 1; 
```

The `respondsToSelector:` check occurs when the delegate is set, and only **if the delegate is different** than the already stored. Since the code keeps setting the same delegate, the UIScrollView won't recheck the realDelegate for implementations. I fixed the issue by nilling out the delegate, as we as reordering the realDelegate setter, to make sure the UIScrollView queries the correct object.
