### PR TITLE
Don't scroll while setting the text or selection manually

### DIFF
--- a/PSPDFTextView/PSPDFTextView.m
+++ b/PSPDFTextView/PSPDFTextView.m
@@ -77,16 +77,6 @@
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-#pragma mark - UITextInput
-
-- (void)setSelectedTextRange:(UITextRange *)selectedTextRange
-{
-    _settingSelection = YES;
-    [super setSelectedTextRange:selectedTextRange];
-    _settingSelection = NO;
-}
-
-///////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - Caret Scrolling
 
 - (void)scrollRectToVisibleConsideringInsets:(CGRect)rect animated:(BOOL)animated {

--- a/PSPDFTextView/PSPDFTextView.m
+++ b/PSPDFTextView/PSPDFTextView.m
@@ -18,7 +18,10 @@
 @property (nonatomic, weak) id<UITextViewDelegate> realDelegate;
 @end
 
-@implementation PSPDFTextView
+@implementation PSPDFTextView {
+    BOOL _settingText;
+    BOOL _settingSelection;
+}
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - NSObject
@@ -43,6 +46,40 @@
     }else {
         [super setDelegate:delegate];
     }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark - UITextView
+
+- (void)setText:(NSString *)text
+{
+    _settingText = YES;
+    [super setText:text];
+    _settingText = NO;
+}
+
+- (void)setAttributedText:(NSAttributedString *)attributedText
+{
+    _settingText = YES;
+    [super setAttributedText:attributedText];
+    _settingText = NO;
+}
+
+- (void)setSelectedRange:(NSRange)selectedRange
+{
+    _settingSelection = YES;
+    [super setSelectedRange:selectedRange];
+    _settingSelection = NO;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark - UITextInput
+
+- (void)setSelectedTextRange:(UITextRange *)selectedTextRange
+{
+    _settingSelection = YES;
+    [super setSelectedTextRange:selectedTextRange];
+    _settingSelection = NO;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -119,8 +156,10 @@
         [delegate textViewDidChangeSelection:textView];
     }
 
-    // Ensure caret stays visible when we change the caret position (e.g. via keyboard)
-    [self scrollToVisibleCaretAnimated:YES];
+    if (!_settingText && !_settingSelection) {
+        // Ensure caret stays visible when we change the caret position (e.g. via keyboard)
+        [self scrollToVisibleCaretAnimated:YES];
+    }
 }
 
 - (void)textViewDidChange:(UITextView *)textView {


### PR DESCRIPTION
Thanks for open sourcing PSPDFTextView @steipete. It saved me quite a lot of time.

`textViewDidChangeSelection:` was causing unwanted animations that conflicted with my own. The way I see it, when I’m manually setting the text I don’t want any automatic animations or scroll changes, and I can trigger those manually if I need them.

WARNING: this pull request is not backwards-compatible, as before PSPDFTextView was scrolling to the end\* when setting the text and to the end of the selection when setting it. With this commit PSPDFTextView just stays where it is.

\* Not exactly the end, as it might be missing to account the `textContainerInset`. This is most likely is a bug.
