### PR TITLE
Caret fix

### DIFF
--- a/PSPDFTextView/PSPDFTextView.m
+++ b/PSPDFTextView/PSPDFTextView.m
@@ -144,7 +144,11 @@
 }
 
 - (void)scrollToVisibleCaretAnimated:(BOOL)animated {
-    [self scrollRectToVisibleConsideringInsets:[self caretRectForPosition:self.selectedTextRange.end] animated:animated];
+    const CGRect caretRect = [self caretRectForPosition:self.selectedTextRange.end];
+    // The caret is sometimes off by a pixel. When this happens, scrolling to its rect produces a little bounce.
+    // To avoid this, we scroll to its center instead.
+    const CGRect caretCenterRect = CGRectMake(CGRectGetMidX(caretRect), CGRectGetMidY(caretRect), 0, 0);
+    [self scrollRectToVisibleConsideringInsets:caretCenterRect animated:animated];
 }
 
 - (void)scrollToVisibleCaret {


### PR DESCRIPTION
The caret is sometimes off by a pixel. When this happens, scrolling to its rect produces a little 1 pixel bounce. See:

![bug](https://cloud.githubusercontent.com/assets/912531/3275528/8103474c-f33c-11e3-8348-af0e8714967c.gif)

To avoid this, we scroll to its center instead. Result:

![fixed](https://cloud.githubusercontent.com/assets/912531/3275531/85d75998-f33c-11e3-93a2-69719bb714dc.gif)
