### PR TITLE
Issue #12 - Fixing wrong offset with newlines 

### DIFF
--- a/PSPDFTextView/PSPDFTextView.m
+++ b/PSPDFTextView/PSPDFTextView.m
@@ -97,7 +97,7 @@
             // Calculate new content offset.
             CGPoint contentOffset = self.contentOffset;
             if (CGRectGetMinY(rect) < CGRectGetMinY(visibleRect)) { // scroll up
-                contentOffset.y = CGRectGetMinY(rect) - insets.top;
+                contentOffset.y = MAX(CGRectGetMinY(rect) - insets.top, 0);
             }else { // scroll down
                 contentOffset.y = CGRectGetMaxY(rect) + insets.bottom - CGRectGetHeight(self.bounds);
             }
@@ -144,11 +144,12 @@
 }
 
 - (void)scrollToVisibleCaretAnimated:(BOOL)animated {
-    const CGRect caretRect = [self caretRectForPosition:self.selectedTextRange.end];
-    // The caret is sometimes off by a pixel. When this happens, scrolling to its rect produces a little bounce.
-    // To avoid this, we scroll to its center instead.
-    const CGRect caretCenterRect = CGRectMake(CGRectGetMidX(caretRect), CGRectGetMidY(caretRect), 0, 0);
-    [self scrollRectToVisibleConsideringInsets:caretCenterRect animated:animated];
+    UITextPosition *selectedTextRangeEnd = self.selectedTextRange.end;
+    CGRect rect = [self caretRectForPosition:selectedTextRangeEnd];
+    UITextPosition *givenCaretPosition = [self closestPositionToPoint:CGPointMake(CGRectGetMidX(rect), CGRectGetMidY(rect))];
+    if ([self comparePosition:givenCaretPosition toPosition:selectedTextRangeEnd] == NSOrderedSame) {
+        [self scrollRectToVisibleConsideringInsets:rect animated:animated];
+    }
 }
 
 - (void)scrollToVisibleCaret {


### PR DESCRIPTION
Fixing wrong offset with newlines and ensuring the content offset doesn't intentionally get set to a negative value which is causing the text to jump in a perfectly sized text view with a single line.

Not taking any credit for these fixes since they come from other people's suggestions. But there hasn't been any pull requests to update the main repository with these changes. So figured I would do one 👍
